### PR TITLE
docs: update redis client to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ Create API:
 ```js
 // pages/api/feedback.js
 
-import upstash from '@upstash/redis'
+import { Redis } from '@upstash/redis'
 
-const redis = upstash('UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN')
+const redis = new Redis({
+  url: 'UPSTASH_REDIS_REST_URL',
+  token: 'UPSTASH_REDIS_REST_TOKEN'
+})
 
 export default async function FeedbackWidgetAPI(req, res) {
   try {
-    const { error } = await redis.hset('feedback', Date.now(), req.body)
-    if (error) throw error
-
+    await redis.hset('feedback', Date.now(), req.body)
     return res.status(200).json({ message: 'success' })
   } catch (err) {
     return res.status(400).json({ message: err })

--- a/demo/package.json
+++ b/demo/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@tailwindcss/forms": "^0.4.0",
     "@upstash/feedback": "^0.2.0",
-    "@upstash/redis": "^0.2.1",
+    "@upstash/redis": "^1.0.0",
     "next": "^12.0.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/demo/pages/api/feedback.js
+++ b/demo/pages/api/feedback.js
@@ -1,9 +1,10 @@
-import { hset } from '@upstash/redis'
+import { Redis } from '@upstash/redis'
+
+const redis = Redis.fromEnv()
 
 export default async function FeedbackWidgetAPI(req, res) {
   try {
-    const { error } = await hset('feedback', Date.now(), req.body)
-    if (error) throw error
+    await redis.hset('feedback', { [Date.now().toString()]: req.body })
 
     return res.status(200).json({ message: 'success' })
   } catch (err) {

--- a/demo/pnpm-lock.yaml
+++ b/demo/pnpm-lock.yaml
@@ -3,7 +3,7 @@ lockfileVersion: 5.3
 specifiers:
   '@tailwindcss/forms': ^0.4.0
   '@upstash/feedback': ^0.2.0
-  '@upstash/redis': ^0.2.1
+  '@upstash/redis': ^1.0.0
   autoprefixer: ^10.4.2
   next: ^12.0.8
   postcss: ^8.4.5
@@ -14,7 +14,7 @@ specifiers:
 dependencies:
   '@tailwindcss/forms': 0.4.0_tailwindcss@3.0.16
   '@upstash/feedback': 0.2.0
-  '@upstash/redis': 0.2.1
+  '@upstash/redis': 1.0.0
   next: 12.0.8_react-dom@17.0.2+react@17.0.2
   react: 17.0.2
   react-dom: 17.0.2_react@17.0.2
@@ -237,6 +237,15 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       isomorphic-unfetch: 3.1.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@upstash/redis/1.0.0:
+    resolution: {integrity: sha512-N0QsdXzVpU8EWI10O20+hMbBFA7Oi951vnkhMzyAZTcnxnMXk92JcjwYY+1G0aJccktEB5nzGZ9cmNeGQ9tmzg==}
+    engines: {node: '>=10'}
+    dependencies:
+      isomorphic-fetch: 3.0.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -589,6 +598,15 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
     dev: true
+
+  /isomorphic-fetch/3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
+    dependencies:
+      node-fetch: 2.6.7
+      whatwg-fetch: 3.6.2
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /isomorphic-unfetch/3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
@@ -1116,6 +1134,10 @@ packages:
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    dev: false
+
+  /whatwg-fetch/3.6.2:
+    resolution: {integrity: sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==}
     dev: false
 
   /whatwg-url/5.0.0:


### PR DESCRIPTION
Updates the documentation to use `@upstash/redis@v1.0.0`.
Don't merge yet