### PR TITLE
Add aria-label for accessibility

### DIFF
--- a/src/package/trigger-button.tsx
+++ b/src/package/trigger-button.tsx
@@ -18,6 +18,7 @@ export default function TriggerButton({
       onClick={() => {
         onModalShow(!isModalShow)
       }}
+      aria-label="Feedback"
     >
       {isModalShow ? (
         <>


### PR DESCRIPTION
Since there is no visible text displayed along with the Button icon, adding aria-label will be useful for voiceover users. 
